### PR TITLE
Search for keymaps relative to the plugin's dir.

### DIFF
--- a/plugin/mathematic.vim
+++ b/plugin/mathematic.vim
@@ -7,6 +7,9 @@
 "=============================================================
 let s:save_cpo = &cpo
 set cpo&vim
+if !exists("s:script_path")
+    let s:script_path = expand("<sfile>:p:h:h")
+endif
 if !exists("g:mathematic_user_dir")
     let g:mathematic_user_dir = ""
 endif
@@ -15,9 +18,7 @@ if !exists("g:mathematic_fuzzy_match")
 endif
 fun! s:load_keymap() "{{{
     let files = [
-                \"~/.vim/keymap/mathematic.vim",
-                \"~/.vim/localbundle/keymap/mathematic.vim",
-                \"~/.vim/bundle/mathematic.vim/keymap/mathematic.vim",
+                \s:script_path . "/keymap/mathematic.vim",
                 \g:mathematic_user_dir,
                 \]
     let f = ''


### PR DESCRIPTION
Search for keymaps in a directory relative to the directory of the
plugin script instead of guessing paths. This also fixes errors if the
vim directory is in a non-standard location (which you may want if you
want all your config files under ~/.config, for instance).
